### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mahofadecision/f18886dd-bde3-4db2-b692-1b56ac6e153c/1ed09aad-5e90-49cb-912b-f4cb85f38733/_apis/work/boardbadge/a403149b-3449-4cf0-9e9b-a916c803a875)](https://dev.azure.com/mahofadecision/f18886dd-bde3-4db2-b692-1b56ac6e153c/_boards/board/t/1ed09aad-5e90-49cb-912b-f4cb85f38733/Microsoft.RequirementCategory)
 <div align="center">
   <img alt="Logo" src="https://raw.githubusercontent.com/bchiang7/v4/main/src/images/logo.png" width="100" />
 </div>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mahofadecision/f18886dd-bde3-4db2-b692-1b56ac6e153c/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.